### PR TITLE
Add throw Exception when unexpected type comes

### DIFF
--- a/src/Resource/Entity.php
+++ b/src/Resource/Entity.php
@@ -122,6 +122,8 @@ class Entity
                 return (new Assert\Type($response, $value))->assert();
             case 'redirect':
                 return (new Assert\Redirect($response, $value))->assert();
+            default:
+                throw new \Exception('unknown expect type.');
         }
     }
 


### PR DESCRIPTION
- https://github.com/cloudpack/Rorschach/blob/8431596b08b893a532c35760e4125e6f9b2a90af/src/Command/RorschachCommand.php#L77 にて、unexpectedなtypeがswitch文を通った時に、例外を投げるように`default`を追加しました
