### PR TITLE
テストファイル格納ディレクトリ指定オプション追加

### DIFF
--- a/src/Command/RorschachCommand.php
+++ b/src/Command/RorschachCommand.php
@@ -177,10 +177,19 @@ class RorschachCommand extends Command
      */
     private function fetchDirTargets($dir)
     {
+        $targetDir = '';
+        // 相対パス
+        if (substr($dir, 0, 1) == '.') {
+            $targetDir = __DIR__ . '/../../../../'.$dir
+        // 絶対パス
+        } else {
+            $targetDir = $dir;
+        }
+
         $targets = [];
         $finder = new Finder();
         $finder->files()
-            ->in($dir)
+            ->in($targetDir)
             ->name('test*.yml');
         foreach ($finder as $file) {
             $targets[] = $file->getRealPath();

--- a/src/Command/RorschachCommand.php
+++ b/src/Command/RorschachCommand.php
@@ -35,6 +35,12 @@ class RorschachCommand extends Command
                 'binding parameter.'
             )
             ->addOption(
+                'dir',
+                'd',
+                InputOption::VALUE_OPTIONAL,
+                'test files dir.'
+            )
+            ->addOption(
                 'saikou',
                 's',
                 InputOption::VALUE_NONE,
@@ -49,7 +55,11 @@ class RorschachCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $targets = $this->fetchTargets($input->getOption('file'));
+        if ($input->getOption('dir')) {
+            $targets = $this->fetchDirTargets($input->getOption('dir'));
+        } else {
+            $targets = $this->fetchTargets($input->getOption('file'));
+        }
         $binds = $this->fetchBinds($input->getOption('bind'));
 
         $fs = new Filesystem();
@@ -151,6 +161,26 @@ class RorschachCommand extends Command
         $finder = new Finder();
         $finder->files()
             ->in(__DIR__ . '/../../../..')
+            ->name('test*.yml');
+        foreach ($finder as $file) {
+            $targets[] = $file->getRealPath();
+        }
+
+        return $targets;
+    }
+
+    /**
+     * fetch target dir in files.
+     *
+     * @param  string $dir
+     * @return array
+     */
+    private function fetchDirTargets($dir)
+    {
+        $targets = [];
+        $finder = new Finder();
+        $finder->files()
+            ->in($dir)
             ->name('test*.yml');
         foreach ($finder as $file) {
             $targets[] = $file->getRealPath();


### PR DESCRIPTION
```
$ ./vendor/bin/rorschach inspect -s  --dir='/Users/user/src/test_dir'
```

とか

```
 ./vendor/bin/rorschach inspect  -s -r --dir='./tests'
```

相対のほうが便利かもしれないけど
