### PR TITLE
Typeでエラー発生時にどこでエラーがなのかわからないのでカラム名を出力する

### DIFF
--- a/src/Command/RorschachCommand.php
+++ b/src/Command/RorschachCommand.php
@@ -126,7 +126,7 @@ class RorschachCommand extends Command
                             $errResults = [];
                             foreach ($expect as $col => $val) {
                                 $assertResult = (new Assert\Type($response, $col, $val))->assert();
-                                $output->writeln($this->buildMessage($type, "$col:".$val, count($assertResult) === 0));
+                                $output->writeln($this->buildMessage($type, "$col:$val", count($assertResult) === 0));
                                 if (!empty($assertResult)) {
                                     $errResults[] = $assertResult;
                                 }

--- a/src/Command/RorschachCommand.php
+++ b/src/Command/RorschachCommand.php
@@ -126,7 +126,7 @@ class RorschachCommand extends Command
                             $errResults = [];
                             foreach ($expect as $col => $val) {
                                 $assertResult = (new Assert\Type($response, $col, $val))->assert();
-                                $output->writeln($this->buildMessage($type, $val, count($assertResult) === 0));
+                                $output->writeln($this->buildMessage($type, "$col:".$val, count($assertResult) === 0));
                                 if (!empty($assertResult)) {
                                     $errResults[] = $assertResult;
                                 }


### PR DESCRIPTION
- before
```
	[type]	PASSED.	integer
```
- after
```
	[type]	PASSED.	results.data..category:integer
```

buildMessage()で新規のパラメータ追加した方がいい気もしてる