### PR TITLE
objectがnullの場合、array_key_exists()でWARNINGが出るので修正

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -57,6 +57,10 @@ class Parser
      */
     public static function search($pattern, $object)
     {
+        if (is_null($object)) {
+            throw new \Exception('No pattern found:: ' . $pattern);
+        }
+
         $searches = explode('.', $pattern);
         foreach ($searches as $col) {
             // .. の場合は、配列


### PR DESCRIPTION
例えば `{"data":[]}` のような空配列のJSONを評価しようとするとParser::search()の$objectにNULLが入ってきて、Parser::search()内のarray_key_exists()の第二引数にNULLになってしまい、WARNINGが出るので回避対応を実装
```php
            } else if (array_key_exists($col, $object)) {
```
